### PR TITLE
fix: 意図確定後のみ「メッセージを編集する」を表示し、生成中は非表示にする

### DIFF
--- a/src/app/result/page.tsx
+++ b/src/app/result/page.tsx
@@ -424,6 +424,8 @@ function ResultContent() {
       <p className="mt-2 text-sm leading-relaxed text-slate-900">{entry.text}</p>
     </section>
   );
+  const canShowIntentEditButton =
+    isIntentLocked && intentInput.trim().length > 0 && !isIntentGenerating;
 
   return (
     <div className="max-w-4xl mx-auto px-4 py-8">
@@ -623,18 +625,20 @@ function ResultContent() {
                   {intentError}
                 </div>
               )}
-              <button
-                type="button"
-                onClick={() => setIsIntentLocked(false)}
-                className="-mt-10 inline-flex items-center gap-2 text-sm font-semibold text-slate-600 opacity-0 transition group-hover:opacity-100 focus:opacity-100"
-                aria-label="意図を編集"
-                disabled={isIntentGenerating}
-              >
-                <span className="text-base" aria-hidden="true">
-                  ✎
-                </span>
-                メッセージを編集する
-              </button>
+              {canShowIntentEditButton && (
+                <button
+                  type="button"
+                  onClick={() => setIsIntentLocked(false)}
+                  className="-mt-10 inline-flex items-center gap-2 text-sm font-semibold text-slate-600 opacity-0 transition group-hover:opacity-100 focus:opacity-100"
+                  aria-label="意図を編集"
+                  disabled={isIntentGenerating}
+                >
+                  <span className="text-base" aria-hidden="true">
+                    ✎
+                  </span>
+                  メッセージを編集する
+                </button>
+              )}
             </div>
           )}
         </div>


### PR DESCRIPTION
## 概要
結果ページの意図入力フローにおける表示不具合を修正しました。

- 意図を確定する前に `✎ メッセージを編集する` が表示されないように修正
- 意図に基づく回答生成中は編集ボタンを非表示に修正
- 編集可能な状態のときのみ編集ボタンが表示されるように調整

## 原因
編集ボタンが意図入力モードで常時レンダリングされており、見た目上の hover 制御のみだったため、意図未入力・未確定でも表示される経路がありました。

## 変更内容
以下の条件を満たす場合にのみ編集ボタンを表示するガードを追加しました。

- `isIntentLocked`
- `intentInput.trim().length > 0`
- `!isIntentGenerating`

この表示条件を使って、編集ボタンを条件付きレンダリングに変更しています。

## 期待される挙動
- 意図入力モード初期状態（未入力・未確定）: 編集ボタンは表示されない
- 意図確定後（ロック状態）: 編集ボタンが表示される
- 回答生成中: 編集ボタンは表示されない
- 編集ボタン押下後（アンロック）: 編集ボタンは再び表示されない

## 影響範囲
- 結果ページのUI表示制御のみ
- API・データ構造の変更なし
